### PR TITLE
Make genome build mandatory if regions supplied.

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -22,7 +22,7 @@ Parameters
   the same name as the parameters file, minus its extension.
 - `ORGANISM` _Default: Homo Sapiens_. The scientific name of the species the annotation is associated
   with.
-- `GENOME_RELEASE` The genome build if applicable (e.g. `hg19`).
+- `GENOME_RELEASE` **Mandatory** if platform contains chromosomal region information. The genome build if applicable (e.g. `hg19`).
 
 <!-- vim: tw=80 et ft=markdown spell:
 -->

--- a/src/main/groovy/org/transmartproject/batch/beans/StepBuildingConfigurationTrait.groovy
+++ b/src/main/groovy/org/transmartproject/batch/beans/StepBuildingConfigurationTrait.groovy
@@ -34,8 +34,6 @@ import org.springframework.core.io.Resource
 import org.springframework.util.Assert
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean
 import org.transmartproject.batch.batchartifacts.*
-import org.transmartproject.batch.clinical.facts.ClinicalDataRow
-import org.transmartproject.batch.facts.ClinicalFactsRowSet
 import org.transmartproject.batch.support.TokenizerColumnsReplacingHeaderHandler
 
 import static org.springframework.batch.item.file.transform.DelimitedLineTokenizer.DELIMITER_TAB
@@ -131,17 +129,11 @@ trait StepBuildingConfigurationTrait {
     }
 
     ItemProcessor compositeOf(ItemProcessor... processors) {
-        CompositeItemProcessor<ClinicalDataRow, ClinicalFactsRowSet> result =
-                new CompositeItemProcessor<ClinicalDataRow, ClinicalFactsRowSet>()
-        result.setDelegates(processors.toList())
-        result
+        new CompositeItemProcessor(delegates: processors.toList())
     }
 
     ItemWriter compositeOf(ItemWriter... writers) {
-        CompositeItemWriter result =
-                new CompositeItemWriter()
-        result.setDelegates(writers.toList())
-        result
+        new CompositeItemWriter(delegates: writers.toList())
     }
 
     static Step wrapStepWithName(final String name,

--- a/src/main/groovy/org/transmartproject/batch/highdim/datastd/PlatformValidator.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/datastd/PlatformValidator.groovy
@@ -1,17 +1,20 @@
 package org.transmartproject.batch.highdim.datastd
 
+import org.springframework.batch.core.configuration.annotation.JobScope
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
 import org.springframework.validation.Validator
 import org.transmartproject.batch.highdim.platform.Platform
 
 import javax.annotation.Resource
 
-import static org.springframework.context.i18n.LocaleContextHolder.getLocale
-
 /**
  * Validates {@link PlatformOrganismSupport} objects.
  */
-trait PlatformOrganismValidator implements Validator {
+@Component
+@JobScope
+class PlatformValidator implements Validator {
 
     @Resource
     Platform platformObject
@@ -20,14 +23,13 @@ trait PlatformOrganismValidator implements Validator {
         PlatformOrganismSupport.isAssignableFrom(clazz)
     }
 
-    @SuppressWarnings('ReturnNullFromCatchBlock')
     void validate(Object target, Errors errors) {
         assert target instanceof PlatformOrganismSupport
 
         /* platformObject.id should be normalized to uppercase because it comes
            * from the normalized parameter PLATFORM, but it may be that platform
            * name in the data file is not */
-        if (target.gplId.toUpperCase(locale) != platformObject.id) {
+        if (target.gplId.toUpperCase(LocaleContextHolder.locale) != platformObject.id) {
             errors.rejectValue 'gplId', 'expectedConstant',
                     [platformObject.id, target.gplId] as Object[], null
         }

--- a/src/main/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaAnnotationRowValidator.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaAnnotationRowValidator.groovy
@@ -4,7 +4,7 @@ import groovy.util.logging.Slf4j
 import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
-import org.transmartproject.batch.highdim.datastd.PlatformOrganismValidator
+import org.springframework.validation.Validator
 
 /**
  * Validates {@link MrnaAnnotationRow} objects.
@@ -12,7 +12,7 @@ import org.transmartproject.batch.highdim.datastd.PlatformOrganismValidator
 @Component
 @JobScope
 @Slf4j
-class MrnaAnnotationRowValidator implements PlatformOrganismValidator {
+class MrnaAnnotationRowValidator implements Validator {
 
     @Override
     boolean supports(Class<?> clazz) {
@@ -23,8 +23,6 @@ class MrnaAnnotationRowValidator implements PlatformOrganismValidator {
     @SuppressWarnings('ReturnNullFromCatchBlock')
     void validate(Object target, Errors errors) {
         assert target instanceof MrnaAnnotationRow
-
-        PlatformOrganismValidator.super.validate(target, errors)
 
         if (!target.probeName) {
             errors.rejectValue 'probeName', 'required',

--- a/src/main/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaPlatformStepsConfig.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaPlatformStepsConfig.groovy
@@ -3,6 +3,7 @@ package org.transmartproject.batch.highdim.mrna.platform
 import org.springframework.batch.core.Step
 import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemStreamReader
 import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.file.FlatFileItemReader
@@ -14,6 +15,7 @@ import org.transmartproject.batch.batchartifacts.PutInBeanWriter
 import org.transmartproject.batch.beans.JobScopeInterfaced
 import org.transmartproject.batch.beans.StepBuildingConfigurationTrait
 import org.transmartproject.batch.clinical.db.objects.Tables
+import org.transmartproject.batch.highdim.datastd.PlatformValidator
 import org.transmartproject.batch.highdim.platform.AbstractPlatformJobSpecification
 import org.transmartproject.batch.highdim.platform.annotationsload.AnnotationEntity
 import org.transmartproject.batch.highdim.platform.annotationsload.AnnotationEntityMap
@@ -46,14 +48,30 @@ class MrnaPlatformStepsConfig implements StepBuildingConfigurationTrait {
     }
 
     @Bean
+    @JobScope
+    PlatformValidator platformOrganismValidator() {
+        new PlatformValidator()
+    }
+
+    @Bean
+    ItemProcessor<MrnaAnnotationRow, MrnaAnnotationRow> compositeMrnaAnnotationRowValidatingProcessor(
+            PlatformValidator platformOrganismValidator,
+            MrnaAnnotationRowValidator annotationRowValidator
+    ) {
+        compositeOf(
+                new ValidatingItemProcessor(adaptValidator(platformOrganismValidator)),
+                new ValidatingItemProcessor(adaptValidator(annotationRowValidator)),
+        )
+    }
+
+    @Bean
     Step insertAnnotations(
-            MrnaAnnotationRowValidator annotationRowValidator,
+            ItemProcessor compositeMrnaAnnotationRowValidatingProcessor,
             ItemWriter<MrnaAnnotationRow> mrnaAnnotationWriter) {
         steps.get('mainStep')
                 .chunk(chunkSize)
                 .reader(mrnaAnnotationRowReader(null))
-                .processor(new ValidatingItemProcessor(
-                adaptValidator(annotationRowValidator)))
+                .processor(compositeMrnaAnnotationRowValidatingProcessor)
                 .writer(mrnaAnnotationWriter)
                 .listener(lineOfErrorDetectionListener())
                 .listener(progressWriteListener())

--- a/src/main/groovy/org/transmartproject/batch/highdim/platform/chrregion/ChromosomalRegionRowValidator.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/platform/chrregion/ChromosomalRegionRowValidator.groovy
@@ -1,17 +1,14 @@
 package org.transmartproject.batch.highdim.platform.chrregion
 
-import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
-import org.transmartproject.batch.highdim.datastd.ChromosomalRegionValidator
-import org.transmartproject.batch.highdim.datastd.PlatformOrganismValidator
+import org.springframework.validation.Validator
 
 /**
  * Validates {@link org.transmartproject.batch.highdim.platform.chrregion.ChromosomalRegionRow} objects.
  */
 @Component
-@JobScope
-class ChromosomalRegionRowValidator implements ChromosomalRegionValidator, PlatformOrganismValidator {
+class ChromosomalRegionRowValidator implements Validator {
 
     @Override
     boolean supports(Class<?> clazz) {
@@ -19,12 +16,8 @@ class ChromosomalRegionRowValidator implements ChromosomalRegionValidator, Platf
     }
 
     @Override
-    @SuppressWarnings('ReturnNullFromCatchBlock')
     void validate(Object target, Errors errors) {
         assert target instanceof ChromosomalRegionRow
-
-        ChromosomalRegionValidator.super.validate(target, errors)
-        PlatformOrganismValidator.super.validate(target, errors)
 
         if (!target.regionName) {
             errors.rejectValue 'regionName', 'required',

--- a/src/main/groovy/org/transmartproject/batch/highdim/proteomics/platform/ProteomicsAnnotationRowValidator.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/proteomics/platform/ProteomicsAnnotationRowValidator.groovy
@@ -3,15 +3,14 @@ package org.transmartproject.batch.highdim.proteomics.platform
 import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.stereotype.Component
 import org.springframework.validation.Errors
-import org.transmartproject.batch.highdim.datastd.ChromosomalRegionValidator
-import org.transmartproject.batch.highdim.datastd.PlatformOrganismValidator
+import org.springframework.validation.Validator
 
 /**
  * Validates {@link org.transmartproject.batch.highdim.proteomics.platform.ProteomicsAnnotationRow} objects.
  */
 @Component
 @JobScope
-class ProteomicsAnnotationRowValidator implements ChromosomalRegionValidator, PlatformOrganismValidator {
+class ProteomicsAnnotationRowValidator implements Validator {
 
     @Override
     boolean supports(Class<?> clazz) {
@@ -22,9 +21,6 @@ class ProteomicsAnnotationRowValidator implements ChromosomalRegionValidator, Pl
     @SuppressWarnings('ReturnNullFromCatchBlock')
     void validate(Object target, Errors errors) {
         assert target instanceof ProteomicsAnnotationRow
-
-        ChromosomalRegionValidator.super.validate(target, errors)
-        PlatformOrganismValidator.super.validate(target, errors)
 
         if (!target.probesetId) {
             errors.rejectValue 'probesetId', 'required',

--- a/src/main/resources/org/transmartproject/batch/validation_messages.properties
+++ b/src/main/resources/org/transmartproject/batch/validation_messages.properties
@@ -16,6 +16,8 @@ notReadableFile=The path "{0}" does not point to a readable file.
 
 #Chromosomal region platform
 invalidChromosome=Invalid chromosome: {0}
+genReleaseMandatoryIfChrInfoSpecified=Genome release has to be supplied \
+  if there are chromosomal region information.
 
 #CNV
 expectedFlags=Expected flag values "{0}", got "{1}".

--- a/src/test/groovy/org/transmartproject/batch/highdim/datastd/PlatformValidatorTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/highdim/datastd/PlatformValidatorTests.groovy
@@ -1,0 +1,75 @@
+package org.transmartproject.batch.highdim.datastd
+
+import org.junit.Before
+import org.junit.Test
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Errors
+import org.springframework.validation.FieldError
+import org.transmartproject.batch.highdim.platform.Platform
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+/**
+ * Test... {@link PlatformValidator}
+ */
+class PlatformValidatorTests {
+
+    PlatformValidator testee
+    PlatformTestBean platformTestBean
+    Errors errors
+
+    class PlatformTestBean implements PlatformOrganismSupport {
+        String gplId
+        String organism
+    }
+
+    @Before
+    void setUp() {
+        def platform = new Platform(id: 'GPL570', organism: 'Homo Sapiens')
+        testee = new PlatformValidator(platformObject: platform)
+        platformTestBean = new PlatformTestBean(
+                gplId: platform.id,
+                organism: platform.organism
+        )
+        errors = new BeanPropertyBindingResult(platformTestBean, "item")
+    }
+
+    @Test
+    void testValid() {
+        assertThat callValidate().hasErrors(), is(false)
+    }
+
+    @Test
+    void testGplIdMustMatch() {
+        platformTestBean.gplId = 'gpl570' // lowercase, should pass
+        assertThat callValidate().hasErrors(), is(false)
+
+        platformTestBean.gplId = 'GOK580_foobar'
+        Errors errors = callValidate()
+
+        assertThat errors, hasProperty('fieldErrorCount', equalTo(1))
+
+        FieldError err = errors.getFieldError('gplId')
+        assertThat err.code, is(equalTo('expectedConstant'))
+    }
+
+    @Test
+    void testPlatFormMustMatch() {
+        platformTestBean.organism = 'homo sapiens' // lowercase, should pass
+        assertThat callValidate().hasErrors(), is(false)
+
+        platformTestBean.organism = 'hommmmmoo sapiens'// should fail this time
+        FieldError err = callValidate().fieldError
+
+        assertThat err, allOf(
+                hasProperty('rejectedValue', equalTo(platformTestBean.organism)),
+                hasProperty('field', equalTo('organism')),
+                hasProperty('code', equalTo('expectedConstant')))
+    }
+
+    private Errors callValidate() {
+        testee.validate(platformTestBean, errors)
+        errors
+    }
+}

--- a/src/test/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaAnnotationRowValidatorTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/highdim/mrna/platform/MrnaAnnotationRowValidatorTests.groovy
@@ -34,8 +34,7 @@ class MrnaAnnotationRowValidatorTests {
 
     @Before
     void setUp() {
-        platform
-        testee = new MrnaAnnotationRowValidator(platformObject: platform)
+        testee = new MrnaAnnotationRowValidator()
     }
 
     private boolean sampleRowPasses() {
@@ -45,38 +44,6 @@ class MrnaAnnotationRowValidatorTests {
     @Test
     void testBasicAnnotationPasses() {
         assert sampleRowPasses()
-    }
-
-    @Test
-    void testGplIdMustMatch() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.gplId = 'gpl570' // lowercase, should pass
-        assertThat callValidate().hasErrors(), is(false)
-
-        sampleRow.gplId = 'GOK580_foobar'
-        Errors errors = callValidate()
-
-        assertThat errors, hasProperty('fieldErrorCount', equalTo(1))
-
-        FieldError err = errors.getFieldError('gplId')
-        assertThat err.code, is(equalTo('expectedConstant'))
-    }
-
-    @Test
-    void testPlatFormMustMatch() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.organism = 'homo sapiens' // lowercase, should pass
-        assertThat callValidate().hasErrors(), is(false)
-
-        sampleRow.organism = 'hommmmmoo sapiens'// should fail this time
-        FieldError err = callValidate().fieldError
-
-        assertThat err, allOf(
-                hasProperty('rejectedValue', equalTo(sampleRow.organism)),
-                hasProperty('field', equalTo('organism')),
-                hasProperty('code', equalTo('expectedConstant')))
     }
 
     @Test

--- a/src/test/groovy/org/transmartproject/batch/highdim/proteomics/platform/ProteomicsAnnotationRowValidatorTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/highdim/proteomics/platform/ProteomicsAnnotationRowValidatorTests.groovy
@@ -5,7 +5,6 @@ import org.junit.Test
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.Errors
 import org.springframework.validation.FieldError
-import org.transmartproject.batch.highdim.platform.Platform
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
@@ -18,25 +17,18 @@ class ProteomicsAnnotationRowValidatorTests {
 
     ProteomicsAnnotationRowValidator testee
 
-    Platform platform = new Platform(
-            id: 'PROT_ANNOT',
-            title: 'Proteomics Test Annotation',
-            organism: 'Homo Sapiens',
-            markerType: 'PROTEOMICS')
-
     ProteomicsAnnotationRow sampleRow = new ProteomicsAnnotationRow(
-            gplId: platform.id,
+            gplId: 'PROT_ANNOT',
             probesetId: '4041',
             uniprotId: 'Q8WX92',
             chromosome: '9',
             startBp: 140149758,
             endBp: 140168000,
-            organism: platform.organism)
+            organism: 'Homo Sapiens')
 
     @Before
     void setUp() {
-        platform
-        testee = new ProteomicsAnnotationRowValidator(platformObject: platform)
+        testee = new ProteomicsAnnotationRowValidator()
     }
 
     private boolean sampleRowPasses() {
@@ -46,38 +38,6 @@ class ProteomicsAnnotationRowValidatorTests {
     @Test
     void testBasicAnnotationPasses() {
         assert sampleRowPasses()
-    }
-
-    @Test
-    void testGplIdMustMatch() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.gplId = 'prot_annot' // lowercase, should pass
-        assertThat callValidate().hasErrors(), is(false)
-
-        sampleRow.gplId = 'UNEXST'
-        Errors errors = callValidate()
-
-        assertThat errors, hasProperty('fieldErrorCount', equalTo(1))
-
-        FieldError err = errors.getFieldError('gplId')
-        assertThat err.code, is(equalTo('expectedConstant'))
-    }
-
-    @Test
-    void testPlatFormMustMatch() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.organism = 'homo sapiens' // lowercase, should pass
-        assertThat callValidate().hasErrors(), is(false)
-
-        sampleRow.organism = 'hommmmmoo sapiens'// should fail this time
-        FieldError err = callValidate().fieldError
-
-        assertThat err, allOf(
-                hasProperty('rejectedValue', equalTo(sampleRow.organism)),
-                hasProperty('field', equalTo('organism')),
-                hasProperty('code', equalTo('expectedConstant')))
     }
 
     @Test
@@ -114,104 +74,6 @@ class ProteomicsAnnotationRowValidatorTests {
         sampleRow.uniprotId = ''
         err = callValidate().fieldError
         assertThat err, hasProperty('code', equalTo('required'))
-    }
-
-    @Test
-    void testChrPositionOptionality() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.chromosome = null
-        sampleRow.startBp = null
-        sampleRow.endBp = null
-
-        assertThat callValidate().hasErrors(), is(false)
-    }
-
-    @Test
-    void testChrIsEmpty() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.chromosome = null
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', nullValue()),
-                hasProperty('field', equalTo('chromosome')),
-                hasProperty('code', equalTo('required')))
-
-        // empty string should also be rejected
-        sampleRow.chromosome = ''
-        err = callValidate().fieldError
-        assertThat err, hasProperty('code', equalTo('required'))
-    }
-
-    @Test
-    void testChrIsInvalid() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.chromosome = 'F'
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', equalTo(sampleRow.chromosome)),
-                hasProperty('field', equalTo('chromosome')),
-                hasProperty('code', equalTo('invalidChromosome')))
-
-        sampleRow.chromosome = '-1'
-        err = callValidate().fieldError
-        assertThat err, hasProperty('code', equalTo('invalidChromosome'))
-    }
-
-    @Test
-    void testStartBpIsEmpty() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.startBp = null
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', nullValue()),
-                hasProperty('field', equalTo('startBp')),
-                hasProperty('code', equalTo('required')))
-    }
-
-    @Test
-    void testStartBpIsNegative() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.startBp = -1
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', equalTo(sampleRow.startBp)),
-                hasProperty('field', equalTo('startBp')),
-                hasProperty('code', equalTo('connotBeNegative')))
-    }
-
-    @Test
-    void testEndBpIsEmpty() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.endBp = null
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', nullValue()),
-                hasProperty('field', equalTo('endBp')),
-                hasProperty('code', equalTo('required')))
-    }
-
-    @Test
-    void testChrRangeIsInvalid() {
-        assumeThat sampleRowPasses(), is(true)
-
-        sampleRow.endBp = sampleRow.startBp - 1
-
-        FieldError err = callValidate().fieldError
-        assertThat err, allOf(
-                hasProperty('rejectedValue', equalTo(sampleRow.endBp)),
-                hasProperty('field', equalTo('endBp')),
-                hasProperty('code', equalTo('invalidRange')))
     }
 
     private Errors callValidate() {

--- a/studies/PROT_ANNOT/proteomics_annotation.params
+++ b/studies/PROT_ANNOT/proteomics_annotation.params
@@ -2,3 +2,4 @@ PLATFORM=PROT_ANNOT
 TITLE="Test Proteomics Platform"
 ORGANISM="Homo Sapiens"
 ANNOTATIONS_FILE=proteomics_annotation.tsv
+GENOME_RELEASE=hg19


### PR DESCRIPTION
@cataphract  Could you think of any alternative implementation. Because I see several drawbacks of this one: 1. validating genome build each time genome region is validated. 2. I got the field name collision between 2 traits (see `platformObject`). Apparently spring injection works, but it looks weird overall.