### PR TITLE
Move parsing enc. concept path to ConceptFragment.

### DIFF
--- a/src/main/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactory.groovy
+++ b/src/main/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactory.groovy
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component
 import org.transmartproject.batch.clinical.variable.ClinicalVariable
 import org.transmartproject.batch.clinical.xtrial.XtrialMappingCollection
 import org.transmartproject.batch.clinical.xtrial.XtrialNode
+import org.transmartproject.batch.concept.ConceptFragment
 import org.transmartproject.batch.concept.ConceptNode
 import org.transmartproject.batch.concept.ConceptPath
 import org.transmartproject.batch.concept.ConceptTree
@@ -143,7 +144,7 @@ class ClinicalFactsRowSetFactory {
 
         assert var.dataLabel == ClinicalVariable.TEMPLATE
 
-        def relConceptPath = ClinicalVariable.toPath(var.categoryCode)
+        def relConceptPath = ConceptFragment.decode(var.categoryCode).path
 
         if (relConceptPath.contains(ClinicalVariable.SITE_ID_PLACEHOLDER)) {
             def replaceValue = variables.getSiteId(row) ?: ''

--- a/src/main/groovy/org/transmartproject/batch/clinical/variable/ClinicalVariable.groovy
+++ b/src/main/groovy/org/transmartproject/batch/clinical/variable/ClinicalVariable.groovy
@@ -93,11 +93,5 @@ class ClinicalVariable implements Serializable {
         demographicVariable != null
     }
 
-    static String toPath(String columnMappingPathFragment) {
-        columnMappingPathFragment
-            .replace('+', '\\')
-            .replace('_', ' ')
-    }
-
 }
 

--- a/src/main/groovy/org/transmartproject/batch/clinical/variable/ClinicalVariableFieldMapper.groovy
+++ b/src/main/groovy/org/transmartproject/batch/clinical/variable/ClinicalVariableFieldMapper.groovy
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.validation.BindException
 import org.transmartproject.batch.beans.JobScopeInterfaced
+import org.transmartproject.batch.concept.ConceptFragment
 import org.transmartproject.batch.concept.ConceptPath
 import org.transmartproject.batch.patient.DemographicVariable
 
@@ -36,8 +37,8 @@ class ClinicalVariableFieldMapper implements FieldSetMapper<ClinicalVariable> {
     private ClinicalVariable process(ClinicalVariable item) throws Exception {
         if (!ClinicalVariable.RESERVED.contains(item.dataLabel)) {
             ConceptPath path = topNodePath +
-                    ClinicalVariable.toPath(item.categoryCode) +
-                    ClinicalVariable.toPath(item.dataLabel)
+                    ConceptFragment.decode(item.categoryCode) +
+                    ConceptFragment.decode(item.dataLabel)
 
             item.conceptPath = path
         }

--- a/src/main/groovy/org/transmartproject/batch/concept/ConceptPath.groovy
+++ b/src/main/groovy/org/transmartproject/batch/concept/ConceptPath.groovy
@@ -19,6 +19,9 @@ class ConceptPath extends ConceptFragment {
         if (parts.empty) {
             throw new IllegalArgumentException('Full paths cannot be empty')
         }
+        if (this.path[0] != DELIMITER) {
+            throw new IllegalArgumentException("Path should start with ${DELIMITER}")
+        }
     }
 
     ConceptPath(ConceptFragment fragment) {

--- a/src/main/groovy/org/transmartproject/batch/highdim/assays/MappingFileRow.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/assays/MappingFileRow.groovy
@@ -39,15 +39,16 @@ class MappingFileRow {
     ]
 
     ConceptFragment getConceptFragment() {
-        // after TOP_NODE
-        def parts = categoryCd.split('\\+|\\\\').collect {
+        List<String> unprocessedParts = ConceptFragment.decode(categoryCd).parts
+
+        List<String> processedParts = unprocessedParts.collect {
             if (replacements[it]) {
                 replacements[it].call()
             } else {
                 it
             }
-        }.findAll() // remove empty segments
+        }
 
-        new ConceptFragment(parts)
+        new ConceptFragment(processedParts)
     }
 }

--- a/src/main/groovy/org/transmartproject/batch/tag/Tag.groovy
+++ b/src/main/groovy/org/transmartproject/batch/tag/Tag.groovy
@@ -16,7 +16,7 @@ class Tag implements Serializable {
     ConceptFragment conceptFragment
 
     void setConceptFragment(String conceptFragment) {
-        this.conceptFragment = new ConceptFragment(conceptFragment)
+        this.conceptFragment = ConceptFragment.decode(conceptFragment)
     }
 
     String tagTitle

--- a/src/test-func/groovy/org/transmartproject/batch/highdim/mrna/data/MrnaDataCleanScenarioTests.groovy
+++ b/src/test-func/groovy/org/transmartproject/batch/highdim/mrna/data/MrnaDataCleanScenarioTests.groovy
@@ -100,7 +100,7 @@ class MrnaDataCleanScenarioTests implements JobRunningTestTrait {
 
         assertThat r, allOf(
                 hasEntry('pd_sourcesystem_cd', "$STUDY_ID:$subjectId" as String),
-                hasEntry('cd_concept_path', '\\Public Studies\\GSE8581\\Biomarker_Data\\GPL570_BOGUS\\Lung\\'),
+                hasEntry('cd_concept_path', '\\Public Studies\\GSE8581\\Biomarker Data\\GPL570_BOGUS\\Lung\\'),
                 hasEntry(is('assay_id'), isA(Number)),
                 hasEntry('sample_type', 'Human'),
                 hasEntry('trial_name', STUDY_ID),

--- a/src/test/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactoryTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactoryTests.groovy
@@ -5,6 +5,7 @@ import org.junit.Before
 import org.junit.Test
 import org.transmartproject.batch.clinical.variable.ClinicalVariable
 import org.transmartproject.batch.clinical.xtrial.XtrialMappingCollection
+import org.transmartproject.batch.concept.ConceptFragment
 import org.transmartproject.batch.concept.ConceptPath
 import org.transmartproject.batch.concept.ConceptTree
 import org.transmartproject.batch.concept.ConceptType
@@ -169,7 +170,7 @@ class ClinicalFactsRowSetFactoryTests {
                     /** Calculated @see ClinicalVariableFieldMapper */
                     conceptPath: it.dataLabel in ClinicalVariable.RESERVED ?
                             null
-                            : topNodePath + ClinicalVariable.toPath(it.categoryCode) + it.dataLabel,
+                            : topNodePath + ConceptFragment.decode(it.categoryCode) + it.dataLabel,
                     demographicVariable: DemographicVariable.getMatching(it.dataLabel),
                     *: it)
         }

--- a/src/test/groovy/org/transmartproject/batch/concept/ConceptPathTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/concept/ConceptPathTests.groovy
@@ -1,0 +1,22 @@
+package org.transmartproject.batch.concept
+
+import org.junit.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+/**
+ * Tests for {@link ConceptPath} and {@link ConceptFragment}
+ */
+class ConceptPathTests {
+
+    @Test
+    void testDecodeConcept() {
+        ConceptFragment decodedConcept = ConceptFragment.decode('A+B_C')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('A\\B C\\')),
+                hasProperty('parts', contains('A', 'B C')),
+        )
+    }
+}

--- a/src/test/groovy/org/transmartproject/batch/highdim/assays/MappingFileRowTests.groovy
+++ b/src/test/groovy/org/transmartproject/batch/highdim/assays/MappingFileRowTests.groovy
@@ -1,15 +1,22 @@
 package org.transmartproject.batch.highdim.assays
 
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.transmartproject.batch.concept.ConceptFragment
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.contains
+import static org.hamcrest.Matchers.equalTo
 
 /**
  * Tests for {@link MappingFileRow}
  */
 class MappingFileRowTests {
+
+    @Rule
+    @SuppressWarnings('PublicInstanceField')
+    public final ExpectedException expectedException = ExpectedException.none()
 
     @Test
     void testCurrentPlaceholders() {
@@ -48,5 +55,25 @@ class MappingFileRowTests {
         ConceptFragment conceptFragment = mappingFileRow.conceptFragment
 
         assertThat conceptFragment.parts, contains('Data', mappingFileRow.timePoint, 'Leaf')
+    }
+
+    @Test
+    void testUnderscoresReplacedBySpaces() {
+        def mappingFileRow = new MappingFileRow(categoryCd: 'A_b+C_d\\E f')
+
+        ConceptFragment conceptFragment = mappingFileRow.conceptFragment
+
+        assertThat conceptFragment.parts, contains('A b', 'C d', 'E f')
+    }
+
+    @Test
+    void testFailOnEmptyNodeNames() {
+        String path = 'A\\\\B'
+        def mappingFileRow = new MappingFileRow(categoryCd: path)
+
+        expectedException.expect(IllegalArgumentException)
+        expectedException.expectMessage(equalTo("Path cannot have empty parts (got '${path}')".toString()))
+
+        mappingFileRow.conceptFragment
     }
 }


### PR DESCRIPTION
Example of encoded path: Biomart_Data+MRNA (_ => space, + => \)
- Reuse this parsing from two places: column mapping file and subject sample mapping file read.
- We do not implicitly drop empty node names anymore (e.g. Biomart_Data\\MRNA\Lung; two slashes points to the empty node name)
- It's alowed now to do not start ConceptFragment string with slash. The complete ConceptPath still has to start with slash.