### PR TITLE
Inserts the dummy "SECURITY" fact for the study

### DIFF
--- a/src/main/groovy/org/transmartproject/batch/secureobject/CreateSecureStudyTasklet.groovy
+++ b/src/main/groovy/org/transmartproject/batch/secureobject/CreateSecureStudyTasklet.groovy
@@ -43,7 +43,7 @@ class CreateSecureStudyTasklet implements Tasklet {
         }
 
         secureObjectDAO.createSecureObject(
-                displayName, studyId, secureObjectToken)
+                displayName, secureObjectToken)
     }
 
     private String getDisplayName() {

--- a/src/main/groovy/org/transmartproject/batch/secureobject/SecureObjectDAO.groovy
+++ b/src/main/groovy/org/transmartproject/batch/secureobject/SecureObjectDAO.groovy
@@ -24,12 +24,16 @@ import org.transmartproject.batch.db.SequenceReserver
 class SecureObjectDAO {
 
     public static final String CLINICAL_TRIAL_SECURE_OBJECT_DATA_TYPE = 'BIO_CLINICAL_TRIAL'
+    public static final String DUMMY_SECURITY_CONCEPT_CD = 'SECURITY'
 
     @Autowired
     private SequenceReserver sequenceReserver
 
     @Value(Tables.SECURE_OBJECT)
     private SimpleJdbcInsert secureObjectInsert
+
+    @Value(Tables.OBSERVATION_FACT)
+    private SimpleJdbcInsert dummySecurityObservationsInsert
 
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate
@@ -38,12 +42,13 @@ class SecureObjectDAO {
     private BioExperimentDAO bioExperimentDAO
 
     void createSecureObject(String displayName,
-                            String studyId,
                             SecureObjectToken token) {
 
-        long bioExperimentId = bioExperimentDAO.findOrCreateBioExperiment(studyId)
+        long bioExperimentId = bioExperimentDAO.findOrCreateBioExperiment(token.studyId)
         Map secureObjectValues = findOrCreateSecureObject(
                 bioExperimentId, displayName, token)
+
+        insertDummySecurityObservation(token)
 
         /* some quick validation */
         if (secureObjectValues['bio_data_id'] != bioExperimentId) {
@@ -70,7 +75,7 @@ class SecureObjectDAO {
                                     AND SO.bio_data_unique_id = :sobj)""",
                 [
                         data_type: CLINICAL_TRIAL_SECURE_OBJECT_DATA_TYPE,
-                        sobj: secureObjectToken.toString()])
+                        sobj     : secureObjectToken.toString()])
     }
 
     int deleteSecureObject(SecureObjectToken secureObjectToken) {
@@ -129,6 +134,8 @@ class SecureObjectDAO {
             throw new IncorrectResultSizeDataAccessException(1)
         }
 
+        deleteDummySecurityObservation(secureObjectToken)
+
         affected
     }
 
@@ -174,4 +181,41 @@ class SecureObjectDAO {
             queryResult
         }
     }
+    /**
+     * Inserts the dummy "SECURITY" fact for the study to prevent existing kettle ETL opening up access to the study.
+     * The original purpose of having such observations is unknown.
+     * The sql insert query that causing the issue could be found here
+     * https://github.com/transmart/transmart-data
+     * /blob/cd7f0e337c98a261336cc4ed1db15590beeec316/ddl/postgres/tm_cz/functions/i2b2_load_security_data.sql#L104
+     */
+    private int insertDummySecurityObservation(SecureObjectToken token) {
+        def row = [
+                sourcesystem_cd: token.studyId,
+                encounter_num  : -1,
+                patient_num    : -1,
+                concept_cd     : DUMMY_SECURITY_CONCEPT_CD,
+                valtype_cd     : 'T',
+                tval_char      : token.toString(),
+                start_date     : new GregorianCalendar(1970, 0, 1).time,
+                import_date    : new Date(),
+                provider_id    : '@',
+                location_cd    : '@',
+                modifier_cd    : token.studyId,
+                valueflag_cd   : '@',
+                instance_num   : 1,
+        ] as Map<String, Object>
+
+        dummySecurityObservationsInsert.execute(row)
+    }
+
+    private int deleteDummySecurityObservation(SecureObjectToken token) {
+        jdbcTemplate.update("""
+                DELETE FROM ${Tables.OBSERVATION_FACT}
+                WHERE sourcesystem_cd = :studyId and concept_cd = :conceptCd""",
+                [
+                        studyId  : token.studyId,
+                        conceptCd: DUMMY_SECURITY_CONCEPT_CD,
+                ])
+    }
+
 }

--- a/src/main/groovy/org/transmartproject/batch/secureobject/SecureObjectToken.groovy
+++ b/src/main/groovy/org/transmartproject/batch/secureobject/SecureObjectToken.groovy
@@ -3,9 +3,6 @@ package org.transmartproject.batch.secureobject
 import org.springframework.batch.core.configuration.annotation.JobScope
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import org.springframework.util.Assert
-
-import javax.annotation.PostConstruct
 
 /**
  * Whatever tranSMART calls a "secure object token". In practice, EXP: plus
@@ -20,15 +17,6 @@ class SecureObjectToken {
 
     @Value("#{jobParameters['SECURITY_REQUIRED']}")
     String securityRequired // should be Y or N
-
-    @PostConstruct
-    void checkSecurityRequiredValue() {
-        if (securityRequired != 'Y' && securityRequired != 'N') {
-            throw new IllegalArgumentException(
-                    "Unexpected SECURITY_REQUIRED value: $securityRequired")
-        }
-        Assert.notNull(studyId, "Study id not given")
-    }
 
     String toString() {
         securityRequired == 'Y' ? "EXP:$studyId" : 'EXP:PUBLIC'

--- a/src/test-func/groovy/org/transmartproject/batch/clinical/ClinicalDataPrivateStudyTests.groovy
+++ b/src/test-func/groovy/org/transmartproject/batch/clinical/ClinicalDataPrivateStudyTests.groovy
@@ -99,5 +99,20 @@ class ClinicalDataPrivateStudyTests implements JobRunningTestTrait {
                 hasEntry('accession', STUDY_ID),)
     }
 
+    @Test
+    void testDummySecurityObservation() {
+        def q = """
+                SELECT *
+                FROM ${Tables.OBSERVATION_FACT} O
+                WHERE O.sourcesystem_cd = :studyId and O.concept_cd = :conceptCd"""
+        def res = queryForList(q, [studyId: STUDY_ID, conceptCd: 'SECURITY'])
+
+        assertThat res, hasSize(1)
+        assertThat res[0], allOf(
+                hasEntry('valtype_cd', 'T'),
+                hasEntry('tval_char', "EXP:$STUDY_ID" as String),
+                hasEntry('modifier_cd', STUDY_ID),
+        )
+    }
 
 }

--- a/src/test-func/groovy/org/transmartproject/batch/clinical/ClinicalDataPublicStudyTests.groovy
+++ b/src/test-func/groovy/org/transmartproject/batch/clinical/ClinicalDataPublicStudyTests.groovy
@@ -1,0 +1,107 @@
+package org.transmartproject.batch.clinical
+
+import org.hamcrest.MatcherAssert
+import org.junit.AfterClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.transmartproject.batch.beans.GenericFunctionalTestConfiguration
+import org.transmartproject.batch.beans.PersistentContext
+import org.transmartproject.batch.clinical.db.objects.Tables
+import org.transmartproject.batch.junit.JobRunningTestTrait
+import org.transmartproject.batch.junit.RunJobRule
+import org.transmartproject.batch.support.TableLists
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+/**
+ * Insertion of a private clinical study.
+ */
+@RunWith(SpringJUnit4ClassRunner)
+@ContextConfiguration(classes = GenericFunctionalTestConfiguration)
+class ClinicalDataPublicStudyTests implements JobRunningTestTrait {
+
+    public static final String STUDY_ID = 'GSE8581'
+
+    @ClassRule
+    public final static TestRule RUN_JOB_RULE = new RunJobRule(
+            "${STUDY_ID}_simple",
+            'clinical',
+            ['-d', 'SECURITY_REQUIRED=N'])
+
+    @AfterClass
+    static void cleanDatabase() {
+        // TODO: implement backout study and call it here
+        PersistentContext.truncator.
+                truncate(TableLists.CLINICAL_TABLES + 'ts_batch.batch_job_instance')
+    }
+
+    @Test
+    void testTopNodeIsUnderPublicStudies() {
+        def q = """
+            SELECT c_fullname
+            FROM ${Tables.I2B2}
+            WHERE sourcesystem_cd = :study
+        """
+        def res = queryForList(q, [study: STUDY_ID], String)
+
+        assertThat res, everyItem(
+                startsWith('\\Public Studies\\GSE8581\\'))
+    }
+
+    @Test
+    void testSecureObjectTokenIsCorrect() {
+        def qSec = """
+            SELECT DISTINCT secure_obj_token
+            FROM ${Tables.I2B2_SECURE} I
+            WHERE sourcesystem_cd = :study"""
+        String sot = jdbcTemplate.queryForObject(qSec, [study: STUDY_ID], String)
+
+        MatcherAssert.assertThat sot, is("EXP:PUBLIC" as String)
+    }
+
+    @Test
+    void testBioExperiment() {
+        def q = """
+                SELECT bio_experiment_id, etl_id, title
+                FROM ${Tables.BIO_EXPERIMENT}
+                WHERE accession = :study"""
+
+        def res = queryForList(q, [study: STUDY_ID])
+
+        assertThat res, hasSize(0)
+    }
+
+    @Test
+    void testSecureObject() {
+        def q = """
+                SELECT S.display_name,
+                        S.data_type,
+                        S.search_secure_object_id,
+                        B.accession
+                FROM ${Tables.SECURE_OBJECT} S
+                LEFT JOIN ${Tables.BIO_EXPERIMENT} B ON (S.bio_data_id = B.bio_experiment_id)
+                WHERE S.bio_data_unique_id = :sot"""
+        def res = queryForList(q, [sot: "EXP:PUBLIC" as String])
+
+        assertThat res, hasSize(0)
+
+    }
+
+    @Test
+    void testDummySecurityObservation() {
+        def q = """
+                SELECT *
+                FROM ${Tables.OBSERVATION_FACT} O
+                WHERE O.sourcesystem_cd = :studyId and O.concept_cd = :conceptCd"""
+        def res = queryForList(q, [studyId: STUDY_ID, conceptCd: 'SECURITY'])
+
+        assertThat res, hasSize(0)
+
+    }
+
+}


### PR DESCRIPTION
to prevent existing kettle ETL opening up access to the study.
The sql insert query that causing the issue could be found here
https://github.com/transmart/transmart-data/blob/cd7f0e337c98a261336cc4ed1db15590beeec316/ddl/postgres/tm_cz/functions/i2b2_load_security_data.sql#L104