### PR TITLE
Preserve DUMMY_SECURITY_CONCEPT_CD for highdim

### DIFF
--- a/src/main/groovy/org/transmartproject/batch/facts/DeleteObservationFactTasklet.groovy
+++ b/src/main/groovy/org/transmartproject/batch/facts/DeleteObservationFactTasklet.groovy
@@ -39,7 +39,7 @@ class DeleteObservationFactTasklet extends GenericTableUpdateTasklet {
                 SELECT c_basecode FROM i2b2metadata.i2b2
                 WHERE sourcesystem_cd = ?
                 AND c_visualattributes ${highDim ? '' : 'NOT'} LIKE '__H' ESCAPE '\\'
-                $baseNodePart) or concept_cd='SECURITY')"""
+                $baseNodePart) ${highDim ? "" : "or concept_cd='SECURITY'"})"""
 
         log.debug("Query is $q")
         q

--- a/src/test-func/groovy/org/transmartproject/batch/highdim/rnaseq/data/RnaSeqDataReUploadTests.groovy
+++ b/src/test-func/groovy/org/transmartproject/batch/highdim/rnaseq/data/RnaSeqDataReUploadTests.groovy
@@ -35,10 +35,10 @@ class RnaSeqDataReUploadTests implements JobRunningTestTrait {
 
     @ClassRule
     public final static TestRule RUN_JOB_RULES = new RuleChain([
-            new RunJobRule(STUDY_ID, 'rnaseq', ['-n']),
-            new RunJobRule(STUDY_ID, 'rnaseq'),
+            new RunJobRule(STUDY_ID, 'rnaseq', ['-n', '-d', 'SECURITY_REQUIRED=Y']),
+            new RunJobRule(STUDY_ID, 'rnaseq', ['-d', 'SECURITY_REQUIRED=Y']),
             new RunJobRule(PLATFORM_ID, 'rnaseq_annotation'),
-            new RunJobRule(STUDY_ID, 'clinical'),
+            new RunJobRule(STUDY_ID, 'clinical', ['-d', 'SECURITY_REQUIRED=Y']),
     ])
 
     // needed by the trait
@@ -68,5 +68,14 @@ class RnaSeqDataReUploadTests implements JobRunningTestTrait {
 
         assertThat count,
                 is(equalTo(NUMBER_OF_ASSAYS * NUMBER_OF_REGIONS))
+    }
+
+    @Test
+    void testSecurityRecordRemains() {
+        def count = rowCounter.count Tables.OBSERVATION_FACT,
+                'concept_cd = :concept_cd',
+                concept_cd: 'SECURITY'
+
+        assertThat count, equalTo(1l)
     }
 }


### PR DESCRIPTION
The fix for removing a magic security dummy (in
640c602) now no longer remove it for highdim
jobs. This solves the security problem introduced
by Kettle.

After this fix, only a Clinical job should change
the presence of DUMMY_SECURITY_CONCEPT_CD.