### PR TITLE
Allow duplicate clinical variables in column mapping files

### DIFF
--- a/src/main/groovy/org/transmartproject/batch/clinical/ClinicalDataLoadJobConfiguration.groovy
+++ b/src/main/groovy/org/transmartproject/batch/clinical/ClinicalDataLoadJobConfiguration.groovy
@@ -179,13 +179,16 @@ class ClinicalDataLoadJobConfiguration extends AbstractJobConfiguration {
     @JobScope
     DuplicationDetectionProcessor<ClinicalVariable> duplicateClinicalVariableDetector() {
         // equality of ClinicalVariables are based on file and column number
-        new DuplicationDetectionProcessor<ClinicalVariable>(saveState: false)
+        new DuplicationDetectionProcessor<ClinicalVariable>(
+                throwOnRepeated: false,
+                saveState: false)
     }
 
     @Bean
     @JobScope
     DuplicationDetectionProcessor<ClinicalVariable> duplicateDemographicVariablesDetector() {
         new DuplicationDetectionProcessor<ClinicalVariable>(
+                throwOnRepeated: false,
                 saveState: false,
                 calculateKey: { ClinicalVariable it -> it.demographicVariable })
     }
@@ -194,6 +197,7 @@ class ClinicalDataLoadJobConfiguration extends AbstractJobConfiguration {
     @JobScope
     DuplicationDetectionProcessor<ClinicalVariable> duplicateConceptPathDetector() {
         new DuplicationDetectionProcessor<ClinicalVariable>(
+                throwOnRepeated: false,
                 saveState: false,
                 calculateKey: { ClinicalVariable it -> it.conceptPath })
     }


### PR DESCRIPTION
There are reasons for allowing duplicate clinical variables in column mapping files. E.g. different subject subgroups appear in different files, but with the same variables. It is also allowed in the i2b2 flow. If the same subject has multiple values for the same concept, e.g. due to a mistake, we would still get a unique  constraint violation thrown by the DB.