### PR TITLE
Fix for null values in metabolomics data

### DIFF
--- a/src/main/groovy/org/transmartproject/batch/highdim/datastd/FilterNaNsItemProcessor.groovy
+++ b/src/main/groovy/org/transmartproject/batch/highdim/datastd/FilterNaNsItemProcessor.groovy
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 class FilterNaNsItemProcessor implements ItemProcessor<DataPoint, DataPoint> {
     @Override
     DataPoint process(DataPoint item) throws Exception {
-        if (!Double.isNaN(item.value)) {
+        if (item.value != null && !Double.isNaN(item.value)) {
             item
         } // else null (filter out)
     }


### PR DESCRIPTION
Empty cells in metabolomics data files would cause an exception to be thrown in FilterNaNsItemProcessor, since Double.isNaN() can not be applied to null values.